### PR TITLE
fix element assignment bug with float type matrices

### DIFF
--- a/R/bigmemory.R
+++ b/R/bigmemory.R
@@ -602,7 +602,7 @@ SetElements.bm <- function(x, i, j, value)
          'double' = {SetMatrixElements(x@address, as.double(j), as.double(i), 
                                       as.double(value))},
          'float' = {SetMatrixElements(x@address, as.double(j), as.double(i), 
-                                     as.single(value))},
+                                     as.double(value))},
          SetMatrixElements(x@address, as.double(j), as.double(i), 
                            as.integer(value))
          )
@@ -696,8 +696,8 @@ SetCols.bm <- function(x, j, value)
   if ( options()$bigmemory.typecast.warning &&
        ((typeof(value) == "double") && (typeof(x) != "double") ||
        (typeof(value) == "integer" &&
-        (typeof(x) != "double" && typeof(x) != "integer"))) || 
-       (typeof(value) == "double" && (typeof(x) == "float")) 
+        (typeof(x) != "double" && typeof(x) != "integer")) || 
+       (typeof(value) == "double" && (typeof(x) == "float"))) 
        )
   {
     warning(cat("Assignment will down cast from ", typeof(value), " to ",
@@ -766,12 +766,12 @@ SetRows.bm <- function(x, i, value)
   tempi <- CCleanIndices(as.double(i), as.double(nrow(x)))
   if (is.null(tempi[[1]])) stop("Illegal row index usage in extraction.\n")
   if (tempi[[1]]) i <- tempi[[2]]
-
+  
   if ( options()$bigmemory.typecast.warning &&
        ((typeof(value) == "double") && (typeof(x) != "double") ||
        (typeof(value) == "integer" &&
-        (typeof(x) != "double" && typeof(x) != "integer")))  || 
-       (typeof(value) == "double" && (typeof(x) == "float"))
+        (typeof(x) != "double" && typeof(x) != "integer"))  || 
+       (typeof(value) == "double" && (typeof(x) == "float")))
   )
   {
     warning(cat("Assignment will down cast from ", typeof(value), " to ",
@@ -821,9 +821,9 @@ SetRows.bm <- function(x, i, value)
 #   }
   
   switch(typeof(x),
-         'double' = {SetMatrixRows(x@address, as.double(j), as.double(value))},
-         'float' = {SetMatrixRows(x@address, as.double(j), as.single(value))},
-         SetMatrixRows(x@address, as.double(j), as.integer(value))
+         'double' = {SetMatrixRows(x@address, as.double(i), as.double(value))},
+         'float' = {SetMatrixRows(x@address, as.double(i), as.single(value))},
+         SetMatrixRows(x@address, as.double(i), as.integer(value))
   )
   
   return(x)

--- a/inst/include/bigmemory/bigmemoryDefines.h
+++ b/inst/include/bigmemory/bigmemoryDefines.h
@@ -36,7 +36,7 @@ extern "C"
 #define R_DOUBLE_MAX R_PosInf
 
 #define NA_FLOAT FLT_MIN
-#define R_FLT_MIN (1+FLT_MIN)
+#define R_FLT_MIN -FLT_MAX
 #define R_FLT_MAX FLT_MAX
 
 #ifdef HAVE_LONG_DOUBLE

--- a/src/bigmemory.cpp
+++ b/src/bigmemory.cpp
@@ -9,6 +9,23 @@
 
 #include <Rcpp.h>
 
+/* Notes
+ * R does not natively contain float type objects
+ * Therefore, every time you pass object to see they will initially be
+ * double unless they are already within a C/C++ object.
+ *
+ * For example, the SetMatrixElements function
+ * Normally the function looks like this:
+ *  SetMatrixElements<double, double, MatrixAccessor<double> >(...
+ 
+ * Where both the CType and RType are double but with float
+ * types R is still passing only double.  Trying to pass RType
+ * as float will result in all NA values.  So the function ultimately
+ * must still pass double like so:
+ *  SetMatrixElements<float, double, MatrixAccessor<float> >(...
+ */
+ 
+
 template<typename T>
 string ttos(T i)
 {
@@ -345,7 +362,7 @@ SEXP GetIndivMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row)
         return GetIndivMatrixElements<int, int, SepMatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, col, row, INTSXP);
       case 6:
-        return GetIndivMatrixElements<float, float, SepMatrixAccessor<float> >(
+        return GetIndivMatrixElements<float, double, SepMatrixAccessor<float> >(
           pMat, NA_FLOAT, NA_FLOAT, col, row, REALSXP);
       case 8:
         return GetIndivMatrixElements<double,double,SepMatrixAccessor<double> >(
@@ -366,7 +383,7 @@ SEXP GetIndivMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row)
         return GetIndivMatrixElements<int, int, MatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, col, row, INTSXP);
       case 6:
-        return GetIndivMatrixElements<float, float, MatrixAccessor<float> >(
+        return GetIndivMatrixElements<float, double, MatrixAccessor<float> >(
           pMat, NA_FLOAT, NA_FLOAT, col, row, REALSXP);
       case 8:
         return GetIndivMatrixElements<double, double, MatrixAccessor<double> >(
@@ -574,6 +591,7 @@ SEXP GetMatrixAll( BigMatrix *pMat, double NA_C, double NA_R,
     pColumn = mat[i];
     for (j=0; j < numRows; ++j) 
     {
+        //std::cout << pColumn[j] << std::endl;
       pRet[k] = (pColumn[j] == static_cast<CType>(NA_C)) ?  static_cast<RType>(NA_R) : 
                  (static_cast<RType>(pColumn[j]));
       ++k;
@@ -2012,7 +2030,7 @@ SEXP GetMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row)
           (pMat, NA_INTEGER, NA_INTEGER, col, row, INTSXP);
       case 6:
         // possibly area of problem (REALSXP -> FLOATSXP???) but I think okay
-        return GetMatrixElements<float, float, SepMatrixAccessor<float> >
+        return GetMatrixElements<float, double, SepMatrixAccessor<float> >
           (pMat, NA_FLOAT, NA_FLOAT, col, row, REALSXP);
       case 8:
         return GetMatrixElements<double, double, SepMatrixAccessor<double> >(
@@ -2033,7 +2051,7 @@ SEXP GetMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row)
         return GetMatrixElements<int, int, MatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, col, row, INTSXP);
       case 6:
-        return GetMatrixElements<float, float, MatrixAccessor<float> >(
+        return GetMatrixElements<float, double, MatrixAccessor<float> >(
           pMat, NA_FLOAT, NA_FLOAT, col, row, REALSXP);
       case 8:
         return GetMatrixElements<double, double, MatrixAccessor<double> >
@@ -2061,7 +2079,7 @@ SEXP GetMatrixRows(SEXP bigMatAddr, SEXP row)
         return GetMatrixRows<int, int, SepMatrixAccessor<int> >
           (pMat, NA_INTEGER, NA_INTEGER, row, INTSXP);
       case 6:
-        return GetMatrixRows<float, float, SepMatrixAccessor<float> >
+        return GetMatrixRows<float, double, SepMatrixAccessor<float> >
           (pMat, NA_FLOAT, NA_FLOAT, row, REALSXP);
       case 8:
         return GetMatrixRows<double, double, SepMatrixAccessor<double> >(
@@ -2082,7 +2100,7 @@ SEXP GetMatrixRows(SEXP bigMatAddr, SEXP row)
         return GetMatrixRows<int, int, MatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, row, INTSXP);
       case 6:
-        return GetMatrixRows<float, float, MatrixAccessor<float> >(
+        return GetMatrixRows<float, double, MatrixAccessor<float> >(
           pMat, NA_FLOAT, NA_FLOAT, row, REALSXP);
       case 8:
         return GetMatrixRows<double, double, MatrixAccessor<double> >
@@ -2110,7 +2128,7 @@ SEXP GetMatrixCols(SEXP bigMatAddr, SEXP col)
         return GetMatrixCols<int, int, SepMatrixAccessor<int> >
           (pMat, NA_INTEGER, NA_INTEGER, col, INTSXP);
       case 6:
-        return GetMatrixCols<float, float, SepMatrixAccessor<float> >
+        return GetMatrixCols<float, double, SepMatrixAccessor<float> >
           (pMat, NA_FLOAT, NA_FLOAT, col, REALSXP);
       case 8:
         return GetMatrixCols<double, double, SepMatrixAccessor<double> >(
@@ -2131,7 +2149,7 @@ SEXP GetMatrixCols(SEXP bigMatAddr, SEXP col)
         return GetMatrixCols<int, int, MatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, col, INTSXP);
       case 6:
-        return GetMatrixCols<float, float, MatrixAccessor<float> >(
+        return GetMatrixCols<float, double, MatrixAccessor<float> >(
           pMat, NA_FLOAT, NA_FLOAT, col, REALSXP);
       case 8:
         return GetMatrixCols<double, double, MatrixAccessor<double> >
@@ -2160,7 +2178,7 @@ SEXP GetMatrixAll(SEXP bigMatAddr)
         return GetMatrixAll<int, int, SepMatrixAccessor<int> >
           (pMat, NA_INTEGER, NA_INTEGER, INTSXP);
       case 6:
-        return GetMatrixAll<float, float, SepMatrixAccessor<float> >
+        return GetMatrixAll<float, double, SepMatrixAccessor<float> >
           (pMat, NA_FLOAT, NA_FLOAT, REALSXP);
       case 8:
         return GetMatrixAll<double, double, SepMatrixAccessor<double> >(
@@ -2181,8 +2199,8 @@ SEXP GetMatrixAll(SEXP bigMatAddr)
         return GetMatrixAll<int, int, MatrixAccessor<int> >(
           pMat, NA_INTEGER, NA_INTEGER, INTSXP);
       case 6:
-        return GetMatrixAll<float, float, MatrixAccessor<float> >(
-          pMat, NA_FLOAT, NA_FLOAT, REALSXP);
+        return GetMatrixAll<float, double, MatrixAccessor<float> >(
+          pMat, NA_FLOAT, NA_REAL, REALSXP);
       case 8:
         return GetMatrixAll<double, double, MatrixAccessor<double> >
           (pMat, NA_REAL, NA_REAL, REALSXP);
@@ -2195,6 +2213,7 @@ SEXP GetMatrixAll(SEXP bigMatAddr)
 void SetMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row, SEXP values)
 {
   Rcpp::XPtr<BigMatrix> pMat(bigMatAddr);
+  
   if (pMat->separated_columns())
   {
     switch (pMat->matrix_type())
@@ -2213,7 +2232,7 @@ void SetMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row, SEXP values)
           pMat, col, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixElements<float, float, SepMatrixAccessor<float> >( 
+        SetMatrixElements<float, double, SepMatrixAccessor<float> >( 
           pMat, col, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2239,7 +2258,7 @@ void SetMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row, SEXP values)
           pMat, col, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixElements<float, float, MatrixAccessor<float> >( 
+        SetMatrixElements<float, double, MatrixAccessor<float> >( 
           pMat, col, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2271,7 +2290,7 @@ void SetIndivMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row, SEXP values)
         pMat, col, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
       break;
     case 6:
-      SetIndivMatrixElements<float, float, SepMatrixAccessor<float> >(
+      SetIndivMatrixElements<float, double, SepMatrixAccessor<float> >(
         pMat, col, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
       break;
     case 8:
@@ -2296,7 +2315,7 @@ void SetIndivMatrixElements(SEXP bigMatAddr, SEXP col, SEXP row, SEXP values)
         pMat, col, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
       break;
     case 6:
-      SetIndivMatrixElements<float, float, MatrixAccessor<float> >(
+      SetIndivMatrixElements<float, double, MatrixAccessor<float> >(
         pMat, col, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
       break;
     case 8:
@@ -2328,7 +2347,7 @@ void SetMatrixAll(SEXP bigMatAddr, SEXP values)
           pMat, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixAll<float, float, SepMatrixAccessor<float> >( 
+        SetMatrixAll<float, double, SepMatrixAccessor<float> >( 
           pMat, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2354,7 +2373,7 @@ void SetMatrixAll(SEXP bigMatAddr, SEXP values)
           pMat, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixAll<float, float, MatrixAccessor<float> >( 
+        SetMatrixAll<float, double, MatrixAccessor<float> >( 
           pMat, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2386,7 +2405,7 @@ void SetMatrixCols(SEXP bigMatAddr, SEXP col, SEXP values)
           pMat, col, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixCols<float, float, SepMatrixAccessor<float> >( 
+        SetMatrixCols<float, double, SepMatrixAccessor<float> >( 
           pMat, col, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2412,7 +2431,7 @@ void SetMatrixCols(SEXP bigMatAddr, SEXP col, SEXP values)
           pMat, col, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixCols<float, float, MatrixAccessor<float> >( 
+        SetMatrixCols<float, double, MatrixAccessor<float> >( 
           pMat, col, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2444,7 +2463,7 @@ void SetMatrixRows(SEXP bigMatAddr, SEXP row, SEXP values)
           pMat, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixRows<float, float, SepMatrixAccessor<float> >( 
+        SetMatrixRows<float, double, SepMatrixAccessor<float> >( 
           pMat, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:
@@ -2470,7 +2489,7 @@ void SetMatrixRows(SEXP bigMatAddr, SEXP row, SEXP values)
           pMat, row, values, NA_INTEGER, R_INT_MIN, R_INT_MAX, NA_INTEGER);
         break;
       case 6:
-        SetMatrixRows<float, float, MatrixAccessor<float> >( 
+        SetMatrixRows<float, double, MatrixAccessor<float> >( 
           pMat, row, values, NA_FLOAT, R_FLT_MIN, R_FLT_MAX, NA_FLOAT);
         break;
       case 8:

--- a/tests/testthat/test_float_type.R
+++ b/tests/testthat/test_float_type.R
@@ -1,6 +1,9 @@
 library("bigmemory")
-context("big.matrix Float Type")
+context("big.matrix float type")
 
+options(bigmemory.typecast.warning=FALSE)
+
+set.seed(123)
 z <- filebacked.big.matrix(3, 3, type='float', init=123.0,
                            backingfile="example.bin",
                            descriptorfile="example.desc",
@@ -12,7 +15,10 @@ mat <- matrix(1:9, ncol = 3, nrow = 3, dimnames = list(letters[1:3],
 dmat <- matrix(rnorm(9), ncol = 3, nrow = 3, dimnames = list(letters[1:3], 
                                                        LETTERS[1:3]))
 
-bm <- as.big.matrix(mat, type="float")
+fmat <- big.matrix(3,3, type="float", init = 13.123)
+
+bm <- as.big.matrix(dmat, type="float")
+
 
 test_that("filebacked matrix created successfully",{
     expect_true(file.exists("example.bin"))
@@ -22,14 +28,29 @@ test_that("filebacked matrix created successfully",{
 })
 
 test_that("RAM matrix created successfully",{
-    expect_true(all(bm[,] == mat))
+    expect_equivalent(bm[,], dmat)
     expect_true(typeof(bm) == "float")
+})
+
+test_that("Able to access and assign elements", {
+    fmat[1,3] <- 15.123
+    expect_equivalent(fmat[1,3], 15.123)
+    
+    newRow <- rnorm(3)
+    fmat[1,] <- newRow    
+    expect_equal(fmat[1,], newRow, tolerance = 1e-07)
+
+    newCol <- rnorm(3)
+    fmat[,1] <- newCol
+    expect_equal(fmat[,1], newCol, tolerance = 1e-07)
 })
 
 # Float data types are not typical in R
 # The default warning is a sanity check to realize that
 # any double (i.e. numeric) values passed are down cast to float
+options(bigmemory.typecast.warning=TRUE)
 test_that("Proper warning returned", {
     expect_warning(as.big.matrix(dmat, type="float"), info="Not warning about
                    float type downcast")
 })
+


### PR DESCRIPTION
I have just realized that the assignment of elements in the float matrices was not working properly.  This was a consequence of R not having native `float` support.  The fix mostly consisted of making sure the `RType` typename was set to `double` even with `float` matrices.  The type casting still works correctly and the matrices appear to be working appropriately.  I added extra tests for these points that I overlooked before.