### PR TITLE
Fix DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ Depends: methods, utils, bigmemory.sri
 Imports: Rcpp
 Enhances: biganalytics, bigtabulate, synchronicity
 LinkingTo: BH, Rcpp
-Suggests: testthat
 Description: Create, store, access, and manipulate massive matrices.
   Matrices are allocated to shared memory and may use memory-mapped
   files.  Packages biganalytics, bigtabulate, synchronicity, and


### PR DESCRIPTION
There were two suggests statements which were causing `install_github` to fail.  Removing the additional suggest field fixed the problem.