### PR TITLE
remove warnings by reordering headers

### DIFF
--- a/src/BigMatrix.cpp
+++ b/src/BigMatrix.cpp
@@ -7,6 +7,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <Rcpp.h>
+
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/mapped_region.hpp>
@@ -17,8 +19,6 @@
 #include <boost/interprocess/sync/named_mutex.hpp>
 
 #include "bigmemory/BigMatrix.h"
-
-#include <Rcpp.h>
 
 #define COND_EXCEPTION_PRINT(bYes)                \
   if (bYes)                                       \


### PR DESCRIPTION
This covers only one of the two files emitting a fair amount of warnings. I'll try to get to the other one too.