### PR TITLE
non-continuous element support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ r_github_packages:
   - jimhester/covr
 
 after_success:
-  - Rscript -e 'library(covr);coveralls()'
+  - Rscript --default-packages='utils,stats,methods' -e 'library(covr);coveralls()'

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ GetIndivMatrixElements <- function(bigMatAddr, col, row) {
     .Call('bigmemory_GetIndivMatrixElements', PACKAGE = 'bigmemory', bigMatAddr, col, row)
 }
 
+GetIndivVectorMatrixElements <- function(bigMatAddr, elems) {
+    .Call('bigmemory_GetIndivVectorMatrixElements', PACKAGE = 'bigmemory', bigMatAddr, elems)
+}
+
 ReorderRIntMatrix <- function(matrixVector, nrow, ncol, orderVec) {
     invisible(.Call('bigmemory_ReorderRIntMatrix', PACKAGE = 'bigmemory', matrixVector, nrow, ncol, orderVec))
 }
@@ -195,6 +199,10 @@ GetMatrixAll <- function(bigMatAddr) {
 
 SetMatrixElements <- function(bigMatAddr, col, row, values) {
     invisible(.Call('bigmemory_SetMatrixElements', PACKAGE = 'bigmemory', bigMatAddr, col, row, values))
+}
+
+SetIndivVectorMatrixElements <- function(bigMatAddr, elems, inVec) {
+    invisible(.Call('bigmemory_SetIndivVectorMatrixElements', PACKAGE = 'bigmemory', bigMatAddr, elems, inVec))
 }
 
 SetIndivMatrixElements <- function(bigMatAddr, col, row, values) {

--- a/R/bigmemory.R
+++ b/R/bigmemory.R
@@ -526,6 +526,7 @@ GetAll.bm <- function(x, drop=TRUE)
 #' @docType methods
 #' @rdname extract-methods
 #' @aliases [,big.matrix,ANY,ANY,missing-method
+#' @aliases [<-,big.matrix,ANY,ANY,missing-method
 #' @export
 setMethod("[",
   signature(x = "big.matrix", drop = "missing"),
@@ -1021,7 +1022,7 @@ setMethod('[<-',
 #' @rdname extract-methods
 #' @export
 setMethod('[<-',
-  signature(x = "big.matrix", i="missing", j = "numeric", value = "numeric"),
+  signature(x = "big.matrix", i="missing", j = "numeric"),
   function(x, i, j, value) return(SetCols.bm(x, j, value)))
 
 #' @rdname extract-methods

--- a/R/bigmemory.R
+++ b/R/bigmemory.R
@@ -522,6 +522,7 @@ GetAll.bm <- function(x, drop=TRUE)
 #' @param j Indices specifying the columns
 #' @param drop Logical indication if reduce to minimum dimensions
 #' @param value typically an array-like R object of similar class
+#' @param ... Additional arguments
 #' @docType methods
 #' @rdname extract-methods
 #' @aliases [,big.matrix,ANY,ANY,missing-method

--- a/man-roxygen/core_template.R
+++ b/man-roxygen/core_template.R
@@ -113,7 +113,7 @@
 #' other functions.
 #' @author John W. Emerson and Michael J. Kane 
 #' \email{<bigmemoryauthors@@gmail.com>}
-#' @references The Bigmemory Project: \url{http://www.bigmemory.org/}.\
+#' @references The Bigmemory Project: \url{http://www.bigmemory.org/}.
 #' @seealso \code{\link{bigmemory}}, and perhaps the class documentation of
 #' \code{\linkS4class{big.matrix}}; \code{\link{attach.big.matrix}} and
 #' \code{\link{describe}}.  Sister packages \pkg{biganalytics}, \pkg{bigtabulate},

--- a/man/big.matrix.Rd
+++ b/man/big.matrix.Rd
@@ -239,6 +239,9 @@ z[,]
 John W. Emerson and Michael J. Kane 
 \email{<bigmemoryauthors@gmail.com>}
 }
+\references{
+The Bigmemory Project: \url{http://www.bigmemory.org/}.
+}
 \seealso{
 \code{\link{bigmemory}}, and perhaps the class documentation of
 \code{\linkS4class{big.matrix}}; \code{\link{attach.big.matrix}} and

--- a/man/extract-methods.Rd
+++ b/man/extract-methods.Rd
@@ -15,7 +15,7 @@
 \alias{[<-,big.matrix,matrix,missing,numeric-method}
 \alias{[<-,big.matrix,missing,missing,ANY-method}
 \alias{[<-,big.matrix,missing,missing,numeric-method}
-\alias{[<-,big.matrix,missing,numeric,numeric-method}
+\alias{[<-,big.matrix,missing,numeric,ANY-method}
 \alias{[<-,big.matrix,numeric,missing,numeric-method}
 \alias{[<-,big.matrix,numeric,numeric,ANY-method}
 \title{Extract or Replace}
@@ -42,7 +42,7 @@
 
 \S4method{[}{big.matrix,missing,missing,ANY}(x, i, j) <- value
 
-\S4method{[}{big.matrix,missing,numeric,numeric}(x, i, j) <- value
+\S4method{[}{big.matrix,missing,numeric,ANY}(x, i, j) <- value
 
 \S4method{[}{big.matrix,numeric,missing,numeric}(x, i, j, ...) <- value
 

--- a/man/extract-methods.Rd
+++ b/man/extract-methods.Rd
@@ -12,11 +12,12 @@
 \alias{[,big.matrix,missing,ANY,missing-method}
 \alias{[,big.matrix,missing,missing,logical-method}
 \alias{[,big.matrix,missing,missing,missing-method}
-\alias{[<-,big.matrix,ANY,ANY-method}
-\alias{[<-,big.matrix,ANY,missing-method}
-\alias{[<-,big.matrix,matrix,missing-method}
-\alias{[<-,big.matrix,missing,ANY-method}
-\alias{[<-,big.matrix,missing,missing-method}
+\alias{[<-,big.matrix,matrix,missing,numeric-method}
+\alias{[<-,big.matrix,missing,missing,ANY-method}
+\alias{[<-,big.matrix,missing,missing,numeric-method}
+\alias{[<-,big.matrix,missing,numeric,numeric-method}
+\alias{[<-,big.matrix,numeric,missing,numeric-method}
+\alias{[<-,big.matrix,numeric,numeric,ANY-method}
 \title{Extract or Replace}
 \usage{
 \S4method{[}{big.matrix,ANY,ANY,missing}(x, i, j, drop)
@@ -27,7 +28,7 @@
 
 \S4method{[}{big.matrix,missing,ANY,logical}(x, i, j, drop)
 
-\S4method{[}{big.matrix,ANY,missing,missing}(x, i, j, drop)
+\S4method{[}{big.matrix,ANY,missing,missing}(x, i, j, ..., drop = TRUE)
 
 \S4method{[}{big.matrix,ANY,missing,logical}(x, i, j, drop)
 
@@ -37,15 +38,17 @@
 
 \S4method{[}{big.matrix,matrix,missing,missing}(x, i, j, drop)
 
-\S4method{[}{big.matrix,ANY,ANY}(x, i, j) <- value
+\S4method{[}{big.matrix,numeric,numeric,ANY}(x, i, j) <- value
 
-\S4method{[}{big.matrix,missing,ANY}(x, i, j) <- value
+\S4method{[}{big.matrix,missing,missing,ANY}(x, i, j) <- value
 
-\S4method{[}{big.matrix,ANY,missing}(x, i, j) <- value
+\S4method{[}{big.matrix,missing,numeric,numeric}(x, i, j) <- value
 
-\S4method{[}{big.matrix,missing,missing}(x, i, j) <- value
+\S4method{[}{big.matrix,numeric,missing,numeric}(x, i, j, ...) <- value
 
-\S4method{[}{big.matrix,matrix,missing}(x, i, j) <- value
+\S4method{[}{big.matrix,missing,missing,numeric}(x, i, j) <- value
+
+\S4method{[}{big.matrix,matrix,missing,numeric}(x, i, j) <- value
 }
 \arguments{
 \item{x}{A \code{big.matrix object}}

--- a/man/extract-methods.Rd
+++ b/man/extract-methods.Rd
@@ -59,6 +59,8 @@
 
 \item{drop}{Logical indication if reduce to minimum dimensions}
 
+\item{...}{Additional arguments}
+
 \item{value}{typically an array-like R object of similar class}
 }
 \description{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -18,6 +18,18 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// GetIndivVectorMatrixElements
+SEXP GetIndivVectorMatrixElements(SEXP bigMatAddr, NumericVector elems);
+RcppExport SEXP bigmemory_GetIndivVectorMatrixElements(SEXP bigMatAddrSEXP, SEXP elemsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< SEXP >::type bigMatAddr(bigMatAddrSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type elems(elemsSEXP);
+    __result = Rcpp::wrap(GetIndivVectorMatrixElements(bigMatAddr, elems));
+    return __result;
+END_RCPP
+}
 // ReorderRIntMatrix
 void ReorderRIntMatrix(SEXP matrixVector, SEXP nrow, SEXP ncol, SEXP orderVec);
 RcppExport SEXP bigmemory_ReorderRIntMatrix(SEXP matrixVectorSEXP, SEXP nrowSEXP, SEXP ncolSEXP, SEXP orderVecSEXP) {
@@ -605,6 +617,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type row(rowSEXP);
     Rcpp::traits::input_parameter< SEXP >::type values(valuesSEXP);
     SetMatrixElements(bigMatAddr, col, row, values);
+    return R_NilValue;
+END_RCPP
+}
+// SetIndivVectorMatrixElements
+void SetIndivVectorMatrixElements(SEXP bigMatAddr, NumericVector elems, NumericVector inVec);
+RcppExport SEXP bigmemory_SetIndivVectorMatrixElements(SEXP bigMatAddrSEXP, SEXP elemsSEXP, SEXP inVecSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< SEXP >::type bigMatAddr(bigMatAddrSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type elems(elemsSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type inVec(inVecSEXP);
+    SetIndivVectorMatrixElements(bigMatAddr, elems, inVec);
     return R_NilValue;
 END_RCPP
 }

--- a/tests/testthat/test_assignment.R
+++ b/tests/testthat/test_assignment.R
@@ -1,0 +1,74 @@
+library("bigmemory")
+context("big.matrix assignment")
+
+set.seed(123)
+z <- filebacked.big.matrix(3, 3, type='double', init=123.0,
+                           backingfile="example.bin",
+                           descriptorfile="example.desc",
+                           dimnames=list(c('a','b','c'), c('d', 'e', 'f')))
+
+mat <- matrix(1:9, ncol = 3, nrow = 3, dimnames = list(letters[1:3], 
+                                                       LETTERS[1:3]))
+bm <- as.big.matrix(mat, type = "double")
+z[] <- mat
+
+test_that("Able to assign individual elements", {
+  
+  tmp <- bm[]
+  
+  # element assign
+  bm[1,3] <- 15.123
+  z[1,3] <- 15.123
+  tmp[1,3] <- 15.123
+  
+  expect_equivalent(bm[1,3], 15.123)
+  expect_equivalent(z[1,3], 15.123)
+})
+
+test_that("Able to assign non-contiguous individual elements", {
+  
+  tmp <- bm[]
+  
+  # element assign
+  bm[c(1,3,5)] <- 15.123
+  z[c(1,3,5)] <- 15.123
+  tmp[c(1,3,5)] <- 15.123
+  
+  expect_equivalent(bm[], tmp)
+  expect_equivalent(z[], tmp)
+})
+
+test_that("Able to assign rowwise elements", {
+  
+  row <- rnorm(3)
+  tmp <- bm[]
+  
+  # row assign
+  bm[2,] <- row
+  z[2,] <- row
+  tmp[2,] <- row
+  
+  expect_equivalent(bm[], tmp)
+  expect_equivalent(z[], tmp)
+})
+
+test_that("Able to assign columnwise elements", {
+  
+  col <- rnorm(3)  
+  tmp <- bm[]
+  
+  # column assign
+  bm[,3] <- col
+  z[,3] <- col
+  tmp[,3] <- col
+  
+  expect_equivalent(bm[], tmp)
+  expect_equivalent(z[], tmp)
+})
+
+
+rm(z)
+gc()
+file.remove('example.bin')
+file.remove('example.desc')
+

--- a/tests/testthat/test_assignment.R
+++ b/tests/testthat/test_assignment.R
@@ -19,10 +19,13 @@ test_that("Able to assign individual elements", {
   # element assign
   bm[1,3] <- 15.123
   z[1,3] <- 15.123
-  tmp[1,3] <- 15.123
+  mat[1,3] <- 15.123
   
   expect_equivalent(bm[1,3], 15.123)
   expect_equivalent(z[1,3], 15.123)
+  
+  bm[] <- tmp
+  z[] <- tmp
 })
 
 test_that("Able to assign non-contiguous individual elements", {
@@ -32,10 +35,13 @@ test_that("Able to assign non-contiguous individual elements", {
   # element assign
   bm[c(1,3,5)] <- 15.123
   z[c(1,3,5)] <- 15.123
-  tmp[c(1,3,5)] <- 15.123
+  mat[c(1,3,5)] <- 15.123
   
-  expect_equivalent(bm[], tmp)
-  expect_equivalent(z[], tmp)
+  expect_equivalent(bm[], mat)
+  expect_equivalent(z[], mat)
+  
+  bm[] <- tmp
+  z[] <- tmp
 })
 
 test_that("Able to assign rowwise elements", {
@@ -46,26 +52,48 @@ test_that("Able to assign rowwise elements", {
   # row assign
   bm[2,] <- row
   z[2,] <- row
-  tmp[2,] <- row
+  mat[2,] <- row
   
-  expect_equivalent(bm[], tmp)
-  expect_equivalent(z[], tmp)
+  expect_equivalent(bm[], mat)
+  expect_equivalent(z[], mat)
+  
+  bm[] <- tmp
+  z[] <- tmp
 })
 
 test_that("Able to assign columnwise elements", {
   
-  col <- rnorm(3)  
+  col <- rnorm(3)
   tmp <- bm[]
   
   # column assign
   bm[,3] <- col
   z[,3] <- col
-  tmp[,3] <- col
+  mat[,3] <- col
   
-  expect_equivalent(bm[], tmp)
-  expect_equivalent(z[], tmp)
+  expect_equivalent(bm[], mat)
+  expect_equivalent(z[], mat)
+  
+  bm[] <- tmp
+  z[] <- tmp
 })
 
+
+test_that("Able to assign non-contiguous columns", {
+  
+  tmp <- bm[]
+  
+  # column assign
+  bm[,c(1,3)] <- mat[,c(1,3)]
+  z[,c(1,3)] <- mat[,c(1,3)]
+  mat[,c(1,3)] <- mat[,c(1,3)]
+  
+  expect_equivalent(bm[], mat)
+  expect_equivalent(z[], mat)
+  
+  bm[] <- tmp
+  z[] <- tmp
+})
 
 rm(z)
 gc()

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -31,6 +31,9 @@ test_that("test_read", {
     expect_identical(bmnull[1:2, 2:3], matnull[1:2, 2:3], info = "partial matrix without names")
     expect_identical(bm[, ], mat[, ], info = "full matrix with names")
     expect_identical(bmnull[, ], matnull[, ], info = "full matrix without names")
+    expect_identical(bm[2:5], mat[2:5], info = "continous element specific access")
+    expect_identical(bm[c(2,4,5)], mat[c(2,4,5)], info = "non-continous element specific access")
+    
     mat.list = list(mat[2, , drop = FALSE], mat[, 2, drop = FALSE])
     for (mat in mat.list) {
         matnull = unname(mat)
@@ -57,5 +60,4 @@ test_that("test_read", {
         expect_identical(bm[, ], mat[, ], info = "full matrix with names")
         expect_identical(bmnull[, ], matnull[, ], info = "full matrix without names")
     }
-    return(TRUE)
 })


### PR DESCRIPTION
Previously users could only index single elements or contiguous regions for simple functions like read/write (e.g. `bm[1:3,1:3]`).  These new changes allow users to index non_contiguous elements that mirror the normal R matrix/data.frame syntax for use cases such as `bm[c(1,2,5)]` or `bm[c(2,4)] <- 42`.  Relevant unit tests have been added.