### PR TITLE
Fix low test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ r_github_packages:
 
 after_success:
   - Rscript -e 'devtools::install();library(bigmemory);library(methods);devtools::test()'
-  - Rscript -e 'library(covr);codecov()'
+  - Rscript -e 'library(covr);package_coverage(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ r_github_packages:
 
 after_success:
   - Rscript -e 'devtools::install();library(bigmemory);library(methods);devtools::test()'
-  - Rscript -e 'library(covr);package_coverage(quiet = FALSE)'
+  - Rscript -e 'library(covr);coveralls()'

--- a/src/bigmemory.cpp
+++ b/src/bigmemory.cpp
@@ -123,8 +123,7 @@ SEXP
     BMAccessorType mat(*pMat);
     index_type numElems = elems.size();
     RcppType retVec(numElems);
-    index_type i;
-    int col_end = mat.nrow();
+    index_type i = 0;
     int idx = 0;
     
     for (index_type j = 0; j < elems.size(); j++){
@@ -144,8 +143,7 @@ void
     NumericVector elems, NumericVector inVec)
   {
     BMAccessorType mat(*pMat);
-    index_type numElems = elems.size();
-    index_type i;
+    index_type i = 0;
     
     for (index_type j = 0; j < elems.size(); j++){
       mat[i][static_cast<index_type>(elems[j])-1] = inVec[j];


### PR DESCRIPTION
There was some memory issues with the -O0 flag used by `covr`.  This was in turn caused by some uninitialized variables.  Fixing those solved the problem and should address issue #46.