### PR TITLE
Removing unused variables

### DIFF
--- a/src/bigmemory.cpp
+++ b/src/bigmemory.cpp
@@ -1083,7 +1083,7 @@ SEXP get_order( MatrixAccessorType m, SEXP columns, SEXP naLast,
   index_type col;
   OrderVecs ov;
   ov.reserve(m.nrow());
-  typename OrderVecs::iterator begin, end, it, naIt;
+  typename OrderVecs::iterator it;
   ValueType val;
   for (k=Rf_length(columns)-1; k >= 0; --k)
   {
@@ -1172,7 +1172,7 @@ SEXP get_order2( MatrixAccessorType m, SEXP rows, SEXP naLast,
   index_type row;
   OrderVecs ov;
   ov.reserve(m.ncol());
-  typename OrderVecs::iterator begin, end, it, naIt;
+  typename OrderVecs::iterator it;
   ValueType val;
   for (k=Rf_length(rows)-1; k >= 0; --k)
   {


### PR DESCRIPTION
These caused a bit of noise while compiling the package. Tested with
clang++ 7.0 and -Wall, but probably other compilers would also complain
with a high warning setting.

I initially found this while installing from CRAN, but then realised the git version also suffered from it, so I decided to fix and pull request.