### PR TITLE
define STRICT_R_HEADERS and add one include for FLT_{MIN,MAX}

### DIFF
--- a/inst/include/bigmemory/bigmemoryDefines.h
+++ b/inst/include/bigmemory/bigmemoryDefines.h
@@ -2,6 +2,7 @@
 #ifndef BIGMEMORY_DEFINES_H
 #define BIGMEMORY_DEFINES_H
 
+#include <float.h>             // for FLT_{MIN,MAX}, or use <cfloat> if C++ idioms are preferred
 #include <limits.h>
 #include <stdint.h>
 

--- a/src/BigMatrix.cpp
+++ b/src/BigMatrix.cpp
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <stdint.h>
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 
 #include <boost/interprocess/shared_memory_object.hpp>

--- a/src/bigmemory.cpp
+++ b/src/bigmemory.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 //#include <typeinfo>
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include "bigmemory/BigMatrix.h"
 #include "bigmemory/MatrixAccessor.hpp"

--- a/src/deepcopy.cpp
+++ b/src/deepcopy.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include <boost/lexical_cast.hpp>
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 
 #include "bigmemory/BigMatrix.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,6 @@
 //#include <limits.h>
 //#include <math.h>
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include "bigmemory/util.h"
 


### PR DESCRIPTION
Hi Mike,

Your CRAN package bigmemory uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do.  Please see the discussion at
   https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, I prefixed each #include <Rcpp.h> with STRICT_R_HEADERS which is slightly more extensive then we need to, but it ensures we will not get surprised later.  If you prefer, we can remove this in the PR.  The one change that _is_ needed is the #include <float.h>  (the compiler even suggsted the C++ header  #include <cfloat>). We now can use FLT_MIN and FLT_MAX.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
    https://github.com/RcppCore/Rcpp/issues/1158
to confirm? 

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.